### PR TITLE
Telescope deprecation warning fix

### DIFF
--- a/lua/ronb/plugins/lsp/lspconfig.lua
+++ b/lua/ronb/plugins/lsp/lspconfig.lua
@@ -15,12 +15,17 @@ return {
 
 		local keymap = vim.keymap -- for conciseness
 
+		-- Neovim 0.10+: `vim.loop` is deprecated in favor of `vim.uv`.
+		-- Keep a backwards-compatible fallback without triggering warnings on newer versions.
+		local uv = vim.uv or vim.loop
+
 		-- define htmx manually
 		vim.lsp.config("htmx", {
 			cmd = { vim.fn.expand("~/.cargo/bin/htmx-lsp") },
 			filetypes = { "html", "templ" },
 			root_dir = function()
-				return (vim.fn.getcwd ~= nil and vim.fn.getcwd()) or vim.loop.cwd()
+				-- `vim.fn.getcwd()` should always exist, but keep a safe fallback.
+				return vim.fn.getcwd() or (uv and uv.cwd and uv.cwd())
 			end,
 		})
 		vim.lsp.enable("htmx")


### PR DESCRIPTION
Update LSP config to use `vim.uv` instead of `vim.loop` to resolve a deprecation warning.

Neovim 0.10+ warns on any access to `vim.loop`, which was triggered when opening a file (e.g., after selecting it in Telescope) due to the LSP setup referencing `vim.loop.cwd()`. This change ensures `vim.uv` is preferred, avoiding the warning on modern Neovim versions while maintaining backward compatibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-9ac5faf2-30d8-4bd7-8405-5e2d1144b190"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9ac5faf2-30d8-4bd7-8405-5e2d1144b190"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

